### PR TITLE
Some fixes for existing broken code that came up when working on Odin support

### DIFF
--- a/TACTLib/Core/ConfigHandler.cs
+++ b/TACTLib/Core/ConfigHandler.cs
@@ -22,14 +22,13 @@ namespace TACTLib.Core {
         }
 
         private void LoadFromInstallationInfo<T>(ClientHandler client, string name, out T @out) where T : Config.Config {
-            string key = client.InstallationInfo.Values[name];
-            using (Stream stream = client.OpenConfigKey(key)) {
-                if (client.InstallationInfo.Values.ContainsKey(name)) {
-                    LoadConfig(client, stream, out @out);
-                } else {
-                    @out = null;
-                }
-            }
+	        if (client.InstallationInfo.Values.TryGetValue(name, out string key)) {
+		        using (Stream stream = client.OpenConfigKey(key)) {
+			        LoadConfig(client, stream, out @out);
+		        }
+	        } else {
+		        @out = null;
+	        }
         }
 
         private static void LoadConfig<T>(ClientHandler client, Stream stream, out T @out) {

--- a/TACTLib/Core/ConfigHandler.cs
+++ b/TACTLib/Core/ConfigHandler.cs
@@ -22,13 +22,13 @@ namespace TACTLib.Core {
         }
 
         private void LoadFromInstallationInfo<T>(ClientHandler client, string name, out T @out) where T : Config.Config {
-	        if (client.InstallationInfo.Values.TryGetValue(name, out string key)) {
-		        using (Stream stream = client.OpenConfigKey(key)) {
-			        LoadConfig(client, stream, out @out);
-		        }
-	        } else {
-		        @out = null;
-	        }
+            if (client.InstallationInfo.Values.TryGetValue(name, out string key)) {
+                using (Stream stream = client.OpenConfigKey(key)) {
+                    LoadConfig(client, stream, out @out);
+                }
+            } else {
+                @out = null;
+            }
         }
 
         private static void LoadConfig<T>(ClientHandler client, Stream stream, out T @out) {

--- a/TACTLib/Core/Product/ProductHandlerFactory.cs
+++ b/TACTLib/Core/Product/ProductHandlerFactory.cs
@@ -9,7 +9,7 @@ using TACTLib.Helpers;
 namespace TACTLib.Core.Product {
     public static class ProductHandlerFactory {
         private static readonly Dictionary<TACTProduct, Type> _handlers = new Dictionary<TACTProduct, Type>();
-        
+
         public static IProductHandler GetHandler(TACTProduct product, ClientHandler client, Stream root) {
             var handlerType = GetHandlerType(product);
             if (handlerType == null) return null;
@@ -20,7 +20,7 @@ namespace TACTLib.Core.Product {
 
         public static Type GetHandlerType(TACTProduct product) {
             if (!_handlers.TryGetValue(product, out var type)) {
-                type = Assembly.GetExecutingAssembly().GetTypes().FirstOrDefault(x => typeof(IProductHandler).IsAssignableFrom(x) && x.GetCustomAttribute<ProductHandlerAttribute>()?.Product == product);
+                type = Assembly.GetExecutingAssembly().GetTypes().FirstOrDefault(x => typeof(IProductHandler).IsAssignableFrom(x) && x.GetCustomAttributes<ProductHandlerAttribute>().Any(i => i.Product == product));
             }
             return type;
         }


### PR DESCRIPTION
One fixes an issue with `ConfigHandler` when no Keyring (or other keys) are present in the `.build.info` file and one fixes a crash when `ProductHandlerFactory` tries to access a single attribute in `ProductHandler_MNDX` which has 2.