### PR TITLE
Fix case sensitivity issue for case sensitive filesystems

### DIFF
--- a/TACTLib/TACTProduct.cs
+++ b/TACTLib/TACTProduct.cs
@@ -150,7 +150,7 @@ namespace TACTLib {
             if (File.Exists(Path.Combine(path, "Warcraft III.exe")))
                 return TACTProduct.Warcraft3;
 
-            if (Directory.Exists(Path.Combine(path, "Data"))) {
+            if (Directory.Exists(Path.Combine(path, "Data")) || Directory.Exists(Path.Combine(path, "data"))) {
                 if (File.Exists(Path.Combine(path, "Diablo III.exe")))
                     return TACTProduct.Diablo3;
 


### PR DESCRIPTION
I've changed line 153 from:
`if (Directory.Exists(Path.Combine(path, "Data")))`
to
`if (Directory.Exists(Path.Combine(path, "Data")) || Directory.Exists(Path.Combine(path, "data")))`
