### PR TITLE
Linux CASC init fix

### DIFF
--- a/TACTLib/Container/ContainerHandler.cs
+++ b/TACTLib/Container/ContainerHandler.cs
@@ -50,7 +50,7 @@ namespace TACTLib.Container {
 
         private void LoadIndexFiles() {
             for (int i = 0; i < CASC_INDEX_COUNT; i++) {
-                List<string> files = Directory.EnumerateFiles(Path.Combine(ContainerDirectory, DataDirectory), $"{i:X2}*.idx" + _client.CreateArgs.ExtraFileEnding).ToList();
+                List<string> files = Directory.EnumerateFiles(Path.Combine(ContainerDirectory, DataDirectory), $"{i:X2}*.idx" + _client.CreateArgs.ExtraFileEnding, new EnumerationOptions { MatchCasing = MatchCasing.CaseInsensitive }).ToList();
                 if (files.Count == 0) continue;
 
                 string selectedFile = null;


### PR DESCRIPTION
Now TACTLib doesn't throw an exception on init, but some functionality related to paths is still incompatible with FSes other than NTFS, so for the best experience it's better to mount an NTFS partition and place game files there.