### PR TITLE
Fix path handling on linux

### DIFF
--- a/TACTLib/Config/Keyring.cs
+++ b/TACTLib/Config/Keyring.cs
@@ -30,7 +30,7 @@ namespace TACTLib.Config {
 
 
             if (client.CreateArgs.LoadSupportKeyring) {
-                string keyFile = client.CreateArgs.SupportKeyring ?? Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + $@"\{client.Product:G}.keyring";
+                string keyFile = client.CreateArgs.SupportKeyring ?? Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), $@"{client.Product:G}.keyring");
                 if (File.Exists(keyFile)) {
                     LoadSupportFile(keyFile);
                 }


### PR DESCRIPTION
Fixes "[TRG] can't load bundle because key is missing from the keyring" on linux. Happy New Year btw :)